### PR TITLE
Fix SSLClient port handling

### DIFF
--- a/app/src/main/kotlin/org/example/ssl/SSLClient.kt
+++ b/app/src/main/kotlin/org/example/ssl/SSLClient.kt
@@ -28,7 +28,8 @@ class SSLClient(private val socketFactory: SSLSocketFactory) {
         }
 
         return try {
-            socket = socketFactory.createSocket(url.host, 443) as SSLSocket
+            val port = if (url.port != -1) url.port else url.defaultPort
+            socket = socketFactory.createSocket(url.host, port) as SSLSocket
             socket?.startHandshake()
 
             // Get connection information

--- a/app/src/test/kotlin/org/example/ssl/SSLClientTest.kt
+++ b/app/src/test/kotlin/org/example/ssl/SSLClientTest.kt
@@ -99,6 +99,23 @@ class SSLClientTest {
     }
 
     @Test
+    fun `test connection with custom port`() {
+        val url = URL("https://example.com:8443")
+        `when`(mockSocketFactory.createSocket("example.com", 8443)).thenReturn(mockSocket)
+        `when`(mockSocket.isConnected).thenReturn(true)
+        `when`(mockSocket.isClosed).thenReturn(false)
+        `when`(mockSocket.session).thenReturn(mockSession)
+        `when`(mockSession.cipherSuite).thenReturn("TLS_FAKE_CIPHER")
+        `when`(mockSession.peerCertificates).thenReturn(arrayOf(mock(java.security.cert.X509Certificate::class.java)))
+
+        val result = sslClient.connect(url)
+
+        assert(result.success)
+        verify(mockSocketFactory).createSocket("example.com", 8443)
+        verify(mockSocket).startHandshake()
+    }
+
+    @Test
     fun `test connection with invalid URL protocol`() {
         val url = URL("http://example.com")
         assertThrows<IllegalArgumentException> {


### PR DESCRIPTION
## Summary
- use URL-provided port in `SSLClient.connect`
- test that custom ports are honored

## Testing
- `./gradlew :app:test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684950ed9678832bb875ec71a9a35911