### PR TITLE
Refine and extend unit tests

### DIFF
--- a/app/src/test/kotlin/org/example/cert/CertificateValidatorImplTest.kt
+++ b/app/src/test/kotlin/org/example/cert/CertificateValidatorImplTest.kt
@@ -81,24 +81,6 @@ class CertificateValidatorImplTest {
         assertTrue(result)
     }
 
-    @Test
-    @Disabled("Test fails due to revocation status issues with test certificates")
-    fun `test valid certificate chain with custom validation date`() {
-        // Given
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.DAY_OF_MONTH, 1) // Set date to tomorrow
-        val config = CertificateValidationConfig(validationDate = calendar.time)
-        val validator = CertificateValidatorImpl(config)
-        val leafCert = loadCertificate("certs/leaf.der")
-        val rootCert = loadCertificate("certs/root.der")
-        val certificateChain = arrayOf(leafCert, rootCert)
-
-        // When
-        val result = validator.validateCertificateChain(certificateChain, "example.com")
-
-        // Then
-        assertTrue(result)
-    }
 
     @Test
     fun `test certificate validation with custom key size requirements`() {

--- a/app/src/test/kotlin/org/example/output/ResultFormatterImplTest.kt
+++ b/app/src/test/kotlin/org/example/output/ResultFormatterImplTest.kt
@@ -1,0 +1,47 @@
+package org.example.output
+
+import org.example.model.SSLTestResult
+import org.example.model.ValidationResult
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+class ResultFormatterImplTest {
+    private fun loadCert(path: String): X509Certificate {
+        val stream = this::class.java.classLoader.getResourceAsStream(path) ?: throw IllegalArgumentException("Missing cert $path")
+        return CertificateFactory.getInstance("X.509").generateCertificate(stream) as X509Certificate
+    }
+
+    private fun sampleResult(): SSLTestResult {
+        val cert = loadCert("certs/leaf.der")
+        val validation = ValidationResult(true, true, true, true, "OK")
+        return SSLTestResult(
+            hostname = "example.com",
+            port = 443,
+            protocol = "TLSv1.3",
+            cipherSuite = "TLS_AES_128_GCM_SHA256",
+            certificateChain = listOf(cert),
+            validationResult = validation
+        )
+    }
+
+    @Test
+    fun `format as text`() {
+        val text = ResultFormatterImpl().formatAsText(listOf(sampleResult()))
+        assertTrue(text.contains("example.com:443"))
+        assertTrue(text.contains("TLSv1.3"))
+    }
+
+    @Test
+    fun `format as json`() {
+        val json = ResultFormatterImpl().formatAsJson(listOf(sampleResult()))
+        assertTrue(json.contains("\"hostname\":\"example.com\""))
+    }
+
+    @Test
+    fun `format as yaml`() {
+        val yaml = ResultFormatterImpl().formatAsYaml(listOf(sampleResult()))
+        assertTrue(yaml.contains("hostname: \"example.com\""))
+    }
+}

--- a/app/src/test/kotlin/org/example/ssl/SSLConnectionTesterImplTest.kt
+++ b/app/src/test/kotlin/org/example/ssl/SSLConnectionTesterImplTest.kt
@@ -41,17 +41,6 @@ class SSLConnectionTesterImplTest {
         verify(mockCertificateValidator).validateCertificateChain(certificates, hostname)
     }
 
-    @Test
-    fun `test validate certificate chain with expired certificate`() {
-        // Given
-        val certificates = arrayOf(mockCertificate)
-        val hostname = "example.com"
-        `when`(mockCertificateValidator.validateCertificateChain(certificates, hostname)).thenReturn(false)
-
-        // When/Then
-        sslConnectionTester.validateCertificateChain(certificates, hostname)
-        verify(mockCertificateValidator).validateCertificateChain(certificates, hostname)
-    }
 
     @Test
     fun `test verify hostname`() {

--- a/app/src/test/kotlin/org/example/util/SecurityStrengthAnalyzerTest.kt
+++ b/app/src/test/kotlin/org/example/util/SecurityStrengthAnalyzerTest.kt
@@ -1,0 +1,46 @@
+package org.example.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SecurityStrengthAnalyzerTest {
+    @Test
+    fun `protocol strong`() {
+        assertEquals("STRONG", SecurityStrengthAnalyzer.analyzeProtocol("TLSv1.3"))
+    }
+
+    @Test
+    fun `protocol weak`() {
+        assertEquals("WEAK", SecurityStrengthAnalyzer.analyzeProtocol("SSLv3"))
+    }
+
+    @Test
+    fun `protocol adequate`() {
+        assertEquals("ADEQUATE", SecurityStrengthAnalyzer.analyzeProtocol("TLSv1.4"))
+    }
+
+    @Test
+    fun `protocol unknown`() {
+        assertEquals("UNKNOWN", SecurityStrengthAnalyzer.analyzeProtocol(null))
+    }
+
+    @Test
+    fun `cipher strong`() {
+        assertEquals("STRONG", SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_AES_128_GCM_SHA256"))
+    }
+
+    @Test
+    fun `cipher weak`() {
+        assertEquals("WEAK", SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_RSA_WITH_RC4_128_MD5"))
+    }
+
+    @Test
+    fun `cipher adequate`() {
+        assertEquals("ADEQUATE", SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"))
+    }
+
+    @Test
+    fun `cipher unknown`() {
+        assertEquals("UNKNOWN", SecurityStrengthAnalyzer.analyzeCipherSuite(null))
+    }
+}


### PR DESCRIPTION
## Summary
- remove disabled and duplicate tests
- cover security analysis helpers
- test result formatting

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bbb42fcc0832b9c3f8a5bac9a9236