### PR TITLE
Enhance test coverage and update certificate validator test

### DIFF
--- a/app/src/test/kotlin/org/example/cert/CertificateValidatorImplTest.kt
+++ b/app/src/test/kotlin/org/example/cert/CertificateValidatorImplTest.kt
@@ -82,12 +82,15 @@ class CertificateValidatorImplTest {
     }
 
     @Test
-    @Disabled("Test fails due to revocation status issues with test certificates")
     fun `test valid certificate chain with custom validation date`() {
         // Given
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 1) // Set date to tomorrow
-        val config = CertificateValidationConfig(validationDate = calendar.time)
+        val config = CertificateValidationConfig(
+            validationDate = calendar.time,
+            enableRevocationCheck = false,
+            enableOCSPCheck = false
+        )
         val validator = CertificateValidatorImpl(config)
         val leafCert = loadCertificate("certs/leaf.der")
         val rootCert = loadCertificate("certs/root.der")

--- a/app/src/test/kotlin/org/example/output/ResultFormatterImplTest.kt
+++ b/app/src/test/kotlin/org/example/output/ResultFormatterImplTest.kt
@@ -1,0 +1,51 @@
+package org.example.output
+
+import org.example.model.SSLTestResult
+import org.example.model.ValidationResult
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.security.cert.X509Certificate
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+
+class ResultFormatterImplTest {
+    private fun sampleResult(): SSLTestResult {
+        val cert = Mockito.mock(X509Certificate::class.java)
+        `when`(cert.subjectX500Principal).thenReturn(javax.security.auth.x500.X500Principal("CN=example.com"))
+        `when`(cert.issuerX500Principal).thenReturn(javax.security.auth.x500.X500Principal("CN=issuer.com"))
+        `when`(cert.notAfter).thenReturn(java.util.Date())
+        val validation = ValidationResult(true, true, true, true, "ok")
+        return SSLTestResult(
+            hostname = "example.com",
+            port = 443,
+            protocol = "TLSv1.3",
+            cipherSuite = "TLS_AES_128_GCM_SHA256",
+            certificateChain = listOf(cert),
+            validationResult = validation
+        )
+    }
+
+    @Test
+    fun `formatAsText returns human readable string`() {
+        val formatter = ResultFormatterImpl()
+        val text = formatter.formatAsText(listOf(sampleResult()))
+        assertTrue(text.contains("SSL Test Result for example.com:443"))
+        assertTrue(text.contains("TLS_AES_128_GCM_SHA256"))
+    }
+
+    @Test
+    fun `json and yaml formatting include hostname`() {
+        val formatter = ResultFormatterImpl()
+        val results = listOf(sampleResult())
+        val json = formatter.formatAsJson(results)
+        val yaml = formatter.formatAsYaml(results)
+        assertTrue(json.contains("example.com"))
+        assertTrue(yaml.contains("example.com"))
+    }
+
+    @Test
+    fun `formatAsText handles empty list`() {
+        val formatter = ResultFormatterImpl()
+        assertEquals("No SSL test results to display.", formatter.formatAsText(emptyList()))
+    }
+}

--- a/app/src/test/kotlin/org/example/util/SecurityStrengthAnalyzerTest.kt
+++ b/app/src/test/kotlin/org/example/util/SecurityStrengthAnalyzerTest.kt
@@ -1,0 +1,22 @@
+package org.example.util
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class SecurityStrengthAnalyzerTest {
+    @Test
+    fun `protocol analysis returns expected strength`() {
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_STRONG, SecurityStrengthAnalyzer.analyzeProtocol("TLSv1.3"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_WEAK, SecurityStrengthAnalyzer.analyzeProtocol("TLSv1.0"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_ADEQUATE, SecurityStrengthAnalyzer.analyzeProtocol("TLSv1.4"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_UNKNOWN, SecurityStrengthAnalyzer.analyzeProtocol(null))
+    }
+
+    @Test
+    fun `cipher suite analysis returns expected strength`() {
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_STRONG, SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_WEAK, SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_RSA_WITH_RC4_128_MD5"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_ADEQUATE, SecurityStrengthAnalyzer.analyzeCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA"))
+        assertEquals(SecurityStrengthAnalyzer.STRENGTH_UNKNOWN, SecurityStrengthAnalyzer.analyzeCipherSuite(null))
+    }
+}


### PR DESCRIPTION
## Summary
- enable custom validation date test with revocation disabled
- add unit tests for SecurityStrengthAnalyzer
- add unit tests for ResultFormatterImpl

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bbb687a80832b80ed6c904722d00d